### PR TITLE
Upgrade node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ node_modules/m*
 node_modules/r*
 node_modules/s*
 node_modules/node-sass/**
-public/stylesheets/**
+public/stylesheets
 target
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "connect": "2.30.2",
     "consolidate": "0.x",
     "minimist": "0.0.8",
-    "govuk_frontend_toolkit": "^4.3.0",
+    "govuk_frontend_toolkit": "^4.12.0",
     "govuk_template_mustache": "~0.13.0",
     "node-sass": "2.1.1",
     "grunt": "0.4.5",


### PR DESCRIPTION
Bumping Gov.UK Toolkit to version 4.12.

**Instructions to install**
When this is merged, after you pull the latest copy of master, you will need to open your terminal, go to the nisp-prototype directory and type `npm install`; this will then install the latest version of gov.uk toolkit.