### PR TITLE
Nisp 2040 - Upgrading prototype to use most recent node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You may already have it, try:
 node --version
 ```
 
-Your version needs to be at least v0.10.0.
+Your version needs to be v4.4.7.
 
 If you don't have Node, download it here: [http://nodejs.org/](http://nodejs.org/).
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.0.0",
   "private": true,
   "engines": {
-    "node": "0.10.x"
+    "node": "4.4.7"
   },
   "scripts": {
     "start": "node start.js"
@@ -26,7 +26,7 @@
     "minimist": "0.0.8",
     "govuk_frontend_toolkit": "^4.12.0",
     "govuk_template_mustache": "~0.13.0",
-    "node-sass": "2.1.1",
+    "grunt-sass": "1.2.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.5.0",
@@ -39,6 +39,6 @@
     "nunjucks": "2.1.0"
   },
   "devDependencies": {
-    "node-sass": "^2.1.1"
+    "grunt-sass": "1.2.0"
   }
 }


### PR DESCRIPTION
Must use version 4.4.7 of nodeJS